### PR TITLE
Fix nil error in read_wide_string

### DIFF
--- a/lib/ffi/win32/extensions.rb
+++ b/lib/ffi/win32/extensions.rb
@@ -18,14 +18,14 @@ class FFI::Pointer
 
   # Read +num_bytes+ from a wide character string pointer.
   # If this fails (typically because there are only null characters)
-  # then nil is returned instead.
+  # then an empty string is returned instead.
   #
   def read_wide_string(num_bytes = self.size)
     read_bytes(num_bytes).force_encoding('UTF-16LE')
       .encode('UTF-8', :invalid => :replace, :undef => :replace)
       .split(0.chr).first.force_encoding(Encoding.default_external)
   rescue
-    nil    
+    ""    
   end
 end
 

--- a/lib/ffi/win32/extensions.rb
+++ b/lib/ffi/win32/extensions.rb
@@ -17,11 +17,15 @@ class FFI::Pointer
   end
 
   # Read +num_bytes+ from a wide character string pointer.
+  # If this fails (typically because there are only null characters)
+  # then nil is returned instead.
   #
   def read_wide_string(num_bytes = self.size)
     read_bytes(num_bytes).force_encoding('UTF-16LE')
       .encode('UTF-8', :invalid => :replace, :undef => :replace)
       .split(0.chr).first.force_encoding(Encoding.default_external)
+  rescue
+    nil    
   end
 end
 


### PR DESCRIPTION
If the buffer is empty or contains only null chars this fill fail when calling 'first' as the array is empty.